### PR TITLE
added libcrypto so that BN functions compile

### DIFF
--- a/safeprime.go
+++ b/safeprime.go
@@ -2,7 +2,7 @@
 package safeprime
 
 /*
-#cgo pkg-config: libssl
+#cgo pkg-config: libssl libcrypto
 #include <openssl/bn.h>
 #include <openssl/rand.h>
 


### PR DESCRIPTION
I could not get it to compile on Mac Os X or Ubuntu, getting messages about 
/tmp/go-build563892966/github.com/credentials/safeprime/_obj/safeprime.cgo2.o: In function `openssl_generate_safeprime':
go/src/github.com/credentials/safeprime/safeprime.go:11: undefined reference to `BN_new'
go/src/github.com/credentials/safeprime/safeprime.go:17: undefined reference to `BN_generate_prime_ex'
go/src/github.com/credentials/safeprime/safeprime.go:28: undefined reference to `BN_bn2bin'
go/src/github.com/credentials/safeprime/safeprime.go:30: undefined reference to `BN_free'
go/src/github.com/credentials/safeprime/safeprime.go:18: undefined reference to `BN_free'
collect2: error: ld returned 1 exit status

As it turns out, these functions have been separated in libcrypto since openssl1.x.x. 